### PR TITLE
cargo: Bump rustc-serialize to v0.3.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ buildlib = ["libyubihsm-sys/buildlib"]
 lazy_static = "1.4.0"
 log = "0.3.8"
 regex = "0.2.2"
-rustc-serialize = "0.3.24"
+rustc-serialize = "0.3.25"
 
 [dev-dependencies]
 base64 = "0.7.0"


### PR DESCRIPTION
Currently yubihsm-setup fails to build with:

```
   Compiling rustc-serialize v0.3.24
error[E0310]: the parameter type `T` may not live long enough
    --> /home/obbardc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustc-serialize-0.3.24/src/serialize.rs:1155:5
     |
1155 |     fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |     |
     |     the parameter type `T` must be valid for the static lifetime...
     |     ...so that the type `T` will meet its required lifetime bounds...
     |
note: ...that is required by this bound
    --> /home/obbardc/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/borrow.rs:180:30
     |
180  | pub enum Cow<'a, B: ?Sized + 'a>
     |                              ^^
help: consider adding an explicit lifetime bound
     |
1151 | impl<'a, T: ?Sized + 'static> Decodable for Cow<'a, T>
     |                    +++++++++

For more information about this error, try `rustc --explain E0310`. error: could not compile `rustc-serialize` (lib) due to 1 previous error
```

Fix it by bumping rustc-serialize to a version which contains a fix for the above error.